### PR TITLE
Added configuration for the table_name Athena uses for CUR queries.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,6 +13,7 @@
   * Make sure to select `Enable report data integration for Amazon Athena`
   * Set `Time Granularity` to `Hourly`
   * All other values are up to your personal preference
+  * Make note of the value you use for the `Report name`.  You will need this in step 4 for the `ATHENA` -> `CUR_TABLE_NAME` config setting.
 
 ### 2. Create Glue Crawler
 
@@ -32,7 +33,7 @@ Step 1 will create a cloudformation template for you at
 * Navigate to `AWS Glue`
   * Select `Crawlers`
   * Select `AWSCURCrawler-cur`
-  * Note the `Database` name listed on this page, it will be needed later
+  * Note the `Database` name listed on this page.  You will need this in step 4 for the `ATHENA` -> `CUR_DATABASE` config setting.
 
 ### 3. Install Athena Usage Role
 
@@ -56,6 +57,7 @@ Step 1 will create a cloudformation template for you at
 * Edit `config-example.yaml`
   * You must specify `MASTER` -> `ACCOUNT_ID` or `MASTER` -> `ROLE` if you are running Airle in an account other than master
   * You must specify `ATHENA` -> `CUR_DATABASE` - this must be set to the `Database` value from the `AWS Glue` configuration noted in Step 2
+  * You must specify `ATHENA` -> `CUR_TABLE_NAME` - this must be set to the same value as the `Report name` you chose for the Cost and Usage report in Step 1.  
   * If you would like any reports published to S3, you must update the `CSV_REPORTS` section with the S3 path to publish each reports to
   * If you would like any reports published to RDS, you must update the `PG_REPORTS` section with `DB_HOST`, and the table name to publish each report to
   * All other values you can tune as necessary

--- a/ariel/__init__.py
+++ b/ariel/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the terms of the Apache License, Version 2.0. See LICENSE file for terms.
 __all__ = ['generate_reports', 'get_account_instance_summary', 'get_account_names', 'get_ec2_pricing', 'get_locations',
            'get_reserved_instances', 'get_unlimited_summary', 'get_unused_box_summary', 'utils', 'LOGGER']
-__version__='2.0.0'
+__version__='2.0.1'
 
 import logging
 LOG_LEVEL = logging.INFO

--- a/ariel/get_account_instance_summary.py
+++ b/ariel/get_account_instance_summary.py
@@ -29,6 +29,7 @@ def load(config):
                    utils.get_config_value(config, 'DEFAULTS', 'AWS_REGION',
                                           os.environ.get('AWS_DEFAULT_REGION')))
         database = utils.get_config_value(config, 'ATHENA', 'CUR_DATABASE')
+        table_name = utils.get_config_value(config, 'ATHENA', 'CUR_TABLE_NAME', 'cur')
         staging  = utils.get_config_value(config, 'ATHENA', 'STAGING',
                                           's3://aws-athena-query-results-{0}-{1}/ariel-cur-output/'.format(account, region))
         days     = utils.get_config_value(config, 'ATHENA', 'DAYS', 28)
@@ -74,7 +75,7 @@ def load(config):
             + "              product_operating_system AS operatingsystem, "
             + "              CAST(line_item_usage_amount AS double) as usageamount, "
             + "              CASE WHEN line_item_line_item_type = 'DiscountedUsage' THEN CAST(line_item_usage_amount AS DOUBLE) ELSE 0 END as reservedamount "
-            + "         FROM " + database + ".cur "
+            + "         FROM " + database + "." + table_name
             + "        WHERE product_operation = 'RunInstances' "
             + "          AND line_item_availability_zone != '' "
             + "          AND product_tenancy = 'Shared' "

--- a/ariel/get_locations.py
+++ b/ariel/get_locations.py
@@ -29,6 +29,7 @@ def load(config):
                    utils.get_config_value(config, 'DEFAULTS', 'AWS_REGION',
                                           os.environ.get('AWS_DEFAULT_REGION')))
         database = utils.get_config_value(config, 'ATHENA', 'CUR_DATABASE')
+        table_name = utils.get_config_value(config, 'ATHENA', 'CUR_TABLE_NAME', 'cur')
         staging  = utils.get_config_value(config, 'ATHENA', 'STAGING',
                                           's3://aws-athena-query-results-{0}-{1}/ariel-cur-output/'.format(account, region))
         days     = utils.get_config_value(config, 'ATHENA', 'DAYS', 28)
@@ -60,7 +61,7 @@ def load(config):
         # Retrieve location to region mapping for use with ec2 pricing data
         query = ' '.join((""
             + "SELECT DISTINCT product_location, product_region "
-            + "  FROM " + database + ".cur "
+            + "  FROM " + database + "." + table_name
             + " WHERE line_item_usage_start_date >= cast('{}' as timestamp) ".format(starttime.isoformat(' '))
             + "   AND line_item_usage_start_date < cast('{}' as timestamp) ".format(endtime.isoformat(' '))
             + "   AND product_operation = 'RunInstances' "

--- a/ariel/get_unlimited_summary.py
+++ b/ariel/get_unlimited_summary.py
@@ -29,6 +29,7 @@ def load(config):
                    utils.get_config_value(config, 'DEFAULTS', 'AWS_REGION',
                                           os.environ.get('AWS_DEFAULT_REGION')))
         database = utils.get_config_value(config, 'ATHENA', 'CUR_DATABASE')
+        table_name = utils.get_config_value(config, 'ATHENA', 'CUR_TABLE_NAME', 'cur')
         staging  = utils.get_config_value(config, 'ATHENA', 'STAGING',
                                           's3://aws-athena-query-results-{0}-{1}/ariel-cur-output/'.format(account, region))
         days     = utils.get_config_value(config, 'ATHENA', 'DAYS', 28)
@@ -64,7 +65,7 @@ def load(config):
               "       lower(product_instance) AS instancetypefamily, "
               "       sum(line_item_usage_amount) AS unlimitedusageamount, "
               "       sum(line_item_unblended_cost) AS unlimitedusagecost "
-                          + "  FROM " + database + ".cur "
+                          + "  FROM " + database + "." + table_name
             + " WHERE line_item_usage_type like '%CPUCredits:%' "
             + "   AND line_item_usage_start_date >= cast('{}' as timestamp) ".format(starttime.isoformat(' '))
             + "   AND line_item_usage_start_date < cast('{}' as timestamp) ".format(endtime.isoformat(' '))

--- a/ariel/get_unused_box_summary.py
+++ b/ariel/get_unused_box_summary.py
@@ -29,6 +29,7 @@ def load(config):
                    utils.get_config_value(config, 'DEFAULTS', 'AWS_REGION',
                                           os.environ.get('AWS_DEFAULT_REGION')))
         database = utils.get_config_value(config, 'ATHENA', 'CUR_DATABASE')
+        table_name = utils.get_config_value(config, 'ATHENA', 'CUR_TABLE_NAME', 'cur')
         staging  = utils.get_config_value(config, 'ATHENA', 'STAGING',
                                           's3://aws-athena-query-results-{0}-{1}/ariel-cur-output/'.format(account, region))
         days     = utils.get_config_value(config, 'ATHENA', 'DAYS', 28)
@@ -64,7 +65,7 @@ def load(config):
               "       product_instance_type AS instancetype, "
               "       sum(line_item_usage_amount) AS unusedusageamount, "
               "       sum(line_item_unblended_cost) AS unusedusagecost "
-                          + "  FROM " + database + ".cur "
+                          + "  FROM " + database + "." + table_name
             + " WHERE line_item_usage_type like '%UnusedBox:%' "
             + "   AND line_item_usage_start_date >= cast('{}' as timestamp) ".format(starttime.isoformat(' '))
             + "   AND line_item_usage_start_date < cast('{}' as timestamp) ".format(endtime.isoformat(' '))

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -14,6 +14,9 @@ MASTER:
 ATHENA:
     AWS_REGION:              # Region to execute Athena Query in.  Default: DEFAULTS:AWS_REGION
     CUR_DATABASE: required   # Name of the CUR database.  This should be determined by your CUR export configuration
+    CUR_TABLE_NAME:          # This is the table name used by Athena for the queries and aligns with the cost and usage report name. 
+                             # You can find the create table statement at s3://${BUCKET_NAME}/${PREFIX_NAME}/${REPORT_NAME}/${MONTH_BEGIN_DATE}-${MONTH_END_DATE}/${REPORT_NAME}-create-table.sql
+                             # Default: cur
     STAGING:                 # Temporary S3 bucket for Athena processing.
                              # Default: s3://aws-athena-query-results-${AWS::AccountId}-${AWS::Region}/ariel-cur-output/'
     DAYS:                    # Number of days to analyze.  Default: 28


### PR DESCRIPTION
## Description
Added a new configuration named `CUR_TABLE_NAME` which allows users to create cost and usage reports which are not named `cur`. 

## Related Issue
https://github.com/yahoo/ariel/issues/1

## Motivation and Context
This change is needed so there is not a hard requirement for the name of the cost and usage report.

## How Has This Been Tested?
I created a new cost and usage report with a name besides cur and ran the lambda, inspecting the Cloudwatch logs to make sure it got past that error.  I then ran it against our current production report with the configuration and verified it produced the reports.

## Screenshots (if appropriate):
None needed

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.


## License  
I confirm that this contribution is made under the Apache License, Version 2.0 and that I have the authority necessary to make this contribution on behalf of its copyright owner.