### PR TITLE
Fix issue with i3.metal pricing data not loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Pull Requests are welcome.
 
 ## Maintainers
 Sean Bastille: sean.bastille@verizonmedia.com
+Micah Meckstroth: micah.meckstroth@verizonmedia.com
 
 ## License
 This project is licensed under the terms of the

--- a/ariel/__init__.py
+++ b/ariel/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the terms of the Apache License, Version 2.0. See LICENSE file for terms.
 __all__ = ['generate_reports', 'get_account_instance_summary', 'get_account_names', 'get_ec2_pricing', 'get_locations',
            'get_reserved_instances', 'get_unlimited_summary', 'get_unused_box_summary', 'utils', 'LOGGER']
-__version__='2.0.1'
+__version__='2.0.2'
 
 import logging
 LOG_LEVEL = logging.INFO

--- a/ariel/generate_reports.py
+++ b/ariel/generate_reports.py
@@ -330,7 +330,8 @@ def generate(config, instances, ris, pricing):
                 region_hourly_usage -= az_assigned
 
             # Determine our purchase size for this family
-            types = [key for key in pricing[region].keys() if key.startswith(family + '.')]
+            # Most families have a format of "[family].[size]" for the units except metal instance types which just use their name
+            types = [key for key in pricing[region].keys() if key.startswith(family + '.') or key == family]
             type_units = {key: get_units(key) for key in types}
             desired_size = utils.get_config_value(config, 'RI_PURCHASES', 'RI_SIZE', 'largest')
             if desired_size == 'largest':

--- a/ariel/generate_reports.py
+++ b/ariel/generate_reports.py
@@ -45,7 +45,11 @@ def generate(config, instances, ris, pricing):
     instances.insert(region_column, 'region', region_value)
 
     family_column = instances.columns.get_loc('instancetype')
-    family_value = instances['instancetype'].apply(lambda x: x if x.endswith('.metal') else x.split('.')[0])
+
+    # meckstmd:07/29/2019 - Metal RIs are no different than regular RIs - they are a family with a normalization factor
+    #  for example, i3.metal is equivalent to i3.16xlarge.  See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/apply_ri.html 
+    #family_value = instances['instancetype'].apply(lambda x: x if x.endswith('.metal') else x.split('.')[0])
+    family_value = instances['instancetype'].apply(lambda x: x.split('.')[0])
     instances.insert(family_column, 'instancetypefamily', family_value)
 
     instance_units_column = instances.columns.get_loc('instances') + 2
@@ -58,7 +62,11 @@ def generate(config, instances, ris, pricing):
 
     # Add some additional data to ris
     family_column = ris.columns.get_loc('instancetype') + 1
-    family_value = ris['instancetype'].apply(lambda x: x if x.endswith('.metal') else x.split('.')[0])
+
+    # meckstmd:07/29/2019 - Metal RIs are no different than regular RIs - they are a family with a normalization factor
+    #  for example, i3.metal is equivalent to i3.16xlarge.  See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/apply_ri.html     
+    #family_value = ris['instancetype'].apply(lambda x: x if x.endswith('.metal') else x.split('.')[0])
+    family_value = ris['instancetype'].apply(lambda x: x.split('.')[0])
     ris.insert(family_column, 'instancetypefamily', family_value)
 
     units_column = ris.columns.get_loc('quantity') + 1
@@ -330,8 +338,7 @@ def generate(config, instances, ris, pricing):
                 region_hourly_usage -= az_assigned
 
             # Determine our purchase size for this family
-            # Most families have a format of "[family].[size]" for the units except metal instance types which just use their name
-            types = [key for key in pricing[region].keys() if key.startswith(family + '.') or key == family]
+            types = [key for key in pricing[region].keys() if key.startswith(family + '.')]
             type_units = {key: get_units(key) for key in types}
             desired_size = utils.get_config_value(config, 'RI_PURCHASES', 'RI_SIZE', 'largest')
             if desired_size == 'largest':

--- a/ariel/get_ec2_pricing.py
+++ b/ariel/get_ec2_pricing.py
@@ -149,8 +149,27 @@ def load(config, locations=LOCATIONS):
         return prices
 
 def check_row(header_map, row):
-
-    if row[header_map['Product Family']] != 'Compute Instance':
+    
+    if row[header_map['Product Family']] != 'Compute Instance' and \
+       row[header_map['Product Family']] != 'Compute Instance (bare metal)':        
+        ###################
+        #
+        # meckstmd: 07/24/2019
+        #
+        # These instance types have a Product Family of "Compute Instance (bare metal)"
+        #     i3.metal
+        #     r5.metal
+        #     r5d.metal
+        #     z1d.metal
+        #
+        # These instance types have a Product Family of "Compute Instance"
+        #     c5.metal
+        #     m5.metal
+        #     m5d.metal
+        #
+        #  I am not sure why some metal instances have bare metal in the Product Family name and others do not
+        #
+        ###################
         return False
     if row[header_map['serviceCode']] != 'AmazonEC2':
         return False

--- a/ariel/get_ec2_pricing.py
+++ b/ariel/get_ec2_pricing.py
@@ -150,24 +150,28 @@ def load(config, locations=LOCATIONS):
 
 def check_row(header_map, row):
     
-    if row[header_map['Product Family']] != 'Compute Instance' and \
-       row[header_map['Product Family']] != 'Compute Instance (bare metal)':        
+    if row[header_map['Product Family']] not in ['Compute Instance', 'Compute Instance (bare metal)']:        
         ###################
         #
-        # meckstmd: 07/24/2019
+        # meckstmd: 07/25/2019
         #
-        # These instance types have a Product Family of "Compute Instance (bare metal)"
+        # These metal instance types have a Product Family of "Compute Instance (bare metal)"
         #     i3.metal
         #     r5.metal
         #     r5d.metal
         #     z1d.metal
         #
-        # These instance types have a Product Family of "Compute Instance"
+        # These metal instance types have a Product Family of "Compute Instance"
         #     c5.metal
         #     m5.metal
         #     m5d.metal
         #
-        #  I am not sure why some metal instances have bare metal in the Product Family name and others do not
+        #  From AWS Support Case #6286484301:
+        #   There is no difference in the two families apart from the ones listed in the EC2 instance types 
+        #   details page (https://aws.amazon.com/ec2/instance-types/). There seems to be an overlap of some 
+        #   kind when new instance types were added and that is why you see them differentiated into two families.
+        #   You can ignore this difference in classification for now and once the errors are rectified at our 
+        #   end, you should not see the two families.
         #
         ###################
         return False


### PR DESCRIPTION
## Description
When Ariel retrieves pricing data from AWS it filters it out to only include the subset of data it needs.  One of the filters it uses is `Product Family` which it requires to be `Compute Instance`.  However some of the metal instance types have a Product Family of `"Compute Instance (bare metal)`.  I have opened a support case with AWS to determine what the reasoning is for this difference.

## Related Issue
https://github.com/yahoo/ariel/issues/3

## Motivation and Context
This change fixes an issue in which Ariel will not work if you have `i3.metal`, `r5.metal`, `r5d.metal` or `z1d.metal` instance types in any of your accounts.

## How Has This Been Tested?
This was tested by running it against a test account and verifying the cache file it produces includes the metal instance types listed above that it was missing before. After the `i3.metal` instance made it into our cost and usage report I then tested that it ran far enough to populate the `account_instance_summary` aurora DB table successfully.  I could not fully test the run because the Athena DB was in the `UPDATING` status.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.


## License  
I confirm that this contribution is made under the Apache License, Version 2.0 and that I have the authority necessary to make this contribution on behalf of its copyright owner.