### PR TITLE
Filter out entries with no product_region or product_instance.

### DIFF
--- a/ariel/__init__.py
+++ b/ariel/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the terms of the Apache License, Version 2.0. See LICENSE file for terms.
 __all__ = ['generate_reports', 'get_account_instance_summary', 'get_account_names', 'get_ec2_pricing', 'get_locations',
            'get_reserved_instances', 'get_unlimited_summary', 'get_unused_box_summary', 'utils', 'LOGGER']
-__version__='2.0.2'
+__version__='2.0.3'
 
 import logging
 LOG_LEVEL = logging.INFO


### PR DESCRIPTION
## Description
When running the unlimited report, I filter the data coming back from Athena to make sure it includes the `product_region` and `product_instance` fields.

## Related Issue
https://github.com/yahoo/ariel/issues/5

## Motivation and Context
This solves the issue of Ariel generating an exception and exiting when it tries to write to the `unlimited_usage` Aurora DB table when you have CPUCredits on instances in your account(s).

## How Has This Been Tested?
This has been tested by running against a cost and usage report which has several T3 instances with CPU credits.  After the run, I looked at the report and verified it has values for the `product_region` and `product_instance` fields in all rows.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.


## License  
I confirm that this contribution is made under the Apache License, Version 2.0 and that I have the authority necessary to make this contribution on behalf of its copyright owner.