### PR TITLE
Added mapping so RHEL reserved instances work.

### DIFF
--- a/ariel/__init__.py
+++ b/ariel/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the terms of the Apache License, Version 2.0. See LICENSE file for terms.
 __all__ = ['generate_reports', 'get_account_instance_summary', 'get_account_names', 'get_ec2_pricing', 'get_locations',
            'get_reserved_instances', 'get_unlimited_summary', 'get_unused_box_summary', 'utils', 'LOGGER']
-__version__='2.0.3'
+__version__='2.0.4'
 
 import logging
 LOG_LEVEL = logging.INFO

--- a/ariel/get_reserved_instances.py
+++ b/ariel/get_reserved_instances.py
@@ -49,7 +49,18 @@ def load(config):
                     # Make sure to only capture active RIs
                     endDate = datetime.datetime.strptime(row['Attributes']['endDateTime'], "%Y-%m-%dT%H:%M:%S.000Z")
                     if endDate.date() > datetime.date.today():
-                        operatingSystem = 'Linux' if row['Attributes']['platform'] == 'Linux/UNIX' else row['Attributes']['platform'] # for CUR compatibility
+
+                        # these mappings are needed for CUR compatibility
+                        # the current pricing report uses the following operating systems:
+                        # Linux, RHEL, SUSE, Windows  
+                        platform = row['Attributes']['platform']
+                        if platform == 'Linux/UNIX':
+                             operatingSystem = 'Linux'
+                        elif platform == 'Red Hat Enterprise Linux':
+                             operatingSystem = 'RHEL'
+                        else:
+                            operatingSystem = platform
+
                         ri = {
                             'accountid': int(row['Attributes']['accountId']),
                             'accountname': row['Attributes']['accountName'],


### PR DESCRIPTION
Added mapping so the text for `Red Hat Enterprise Linux` RIs match the pricing data.

## Description
The reserved utilization report lists RIs with a platform of `Red Hat Enterprise Linux` but the pricing data we download lists it as `RHEL`.  We already changed the mapping for `Linux/UNIX` to map to `Linux` but we did not have a mapping for RHEL.

## Related Issue
https://github.com/yahoo/ariel/issues/3

## Motivation and Context
This fixed an issue in which Ariel will error before finishing its processing if any of the accounts have `Red Hat Enterprise Linux` RIs purchased. 

## How Has This Been Tested?
Since we do not have any `Red Hat Enterprise Linux` RIs purchased I cannot duplicate this issue directly to verify this is the issue and verify the fix.  However, I did remove our mapping for `Linux/Unix` --> `Linux` and received the same error (with the different OS text) that https://github.com/yahoo/ariel/issues/3 lists.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.


## License  
I confirm that this contribution is made under the Apache License, Version 2.0 and that I have the authority necessary to make this contribution on behalf of its copyright owner.