### PR TITLE
Fixed issue when accounts have no pre-existing RI purchases.

### DIFF
--- a/ariel/__init__.py
+++ b/ariel/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the terms of the Apache License, Version 2.0. See LICENSE file for terms.
 __all__ = ['generate_reports', 'get_account_instance_summary', 'get_account_names', 'get_ec2_pricing', 'get_locations',
            'get_reserved_instances', 'get_unlimited_summary', 'get_unused_box_summary', 'utils', 'LOGGER']
-__version__='2.0.4'
+__version__='2.0.5'
 
 import logging
 LOG_LEVEL = logging.INFO

--- a/ariel/get_reserved_instances.py
+++ b/ariel/get_reserved_instances.py
@@ -90,6 +90,14 @@ def load(config):
                 break
 
         ris = pd.DataFrame.from_records(ris)
+        if (len(ris) == 0):
+            ris = pd.DataFrame(columns=['accountid','accountname','reservationid','subscriptionid','startdate',
+               'enddate','state','quantity','availabilityzone','region','instancetype',
+               'paymentoption','tenancy','operatingsystem','amortizedhours',
+               'amortizedupfrontprice','amortizedrecurringfee','offeringclass','scope'])
+        else:
+            ris = pd.DataFrame.from_records(ris)
+
         ris.to_csv(cache_file, index=False)
 
     LOGGER.info("Loaded {} reserved instances".format(len(ris)))

--- a/ariel/lambda.py
+++ b/ariel/lambda.py
@@ -60,7 +60,7 @@ def lambda_main(config):
         conn = pg8000.connect(host=connect_host, port=5432, ssl=ssl, database='ariel', user='ariel_rw', password=token)
 
     for key, report in reports.items():
-        store_index = type(report.index) != pd.RangeIndex
+        store_index = type(report.index) != pd.RangeIndex and len(report) > 0
         filename = utils.get_config_value(config, 'CSV_REPORTS', key, '')
         if filename != '':
             LOGGER.info("Writing Report {} to {}...".format(key, filename))


### PR DESCRIPTION
## Description
The Ariel code made assumptions when generating a report that there would always be at least one pre-existing RI for an account.  The changes I made remove that assumption.  I initialize the RI DataFrame to include the column headers even if there are no RIs.  Then when generating the 2 reports which show current RI usage,  I check for a zero length report and return an empty report for those 2 reports.  I also modified the report printouts to not include an empty index column if the report is empty.

## Related Issue
https://github.com/yahoo/ariel/issues/8

## Motivation and Context
This change fixes an issue in which Ariel crashes if there is not at least one RI purchase for one of the accounts.

## How Has This Been Tested?
I could not test directly since we have RIs, but I commented out the code which adds in RIs and was able to duplicate the issue there with the same error message and same behavior. I then made my code changes and Ariel completed and I observed the 2 empty reports for RI usage.  

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.


## License  
I confirm that this contribution is made under the Apache License, Version 2.0 and that I have the authority necessary to make this contribution on behalf of its copyright owner.