### PR TITLE
Maintenance and bugfixes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -80,6 +80,9 @@ Step 1 will create a cloudformation template for you at
   `{ "config": "<S3 URL for your config object>"}`
 * Click on `Test`
 
+NOTE: Please review to [UPGRADE.md](UPGRADE.md) for upgrade considerations.
+
+
 # Optional Aurora DB Install Documentation
 
 The simplest data export method from Ariel is to publish CSV reports to S3, however that is not always the easiest to consume.  Ariel includes optional support for publishing reports to a Postgres compatible database, and we include CloudFormation support for a Postgres compatible Aurora DB Instance.
@@ -98,3 +101,5 @@ This Aurora DB template must be installed in an existing VPC.  You will need to 
 ### 2. Install Schema
 * In a `Terminal` running in your local ariel repository
   * Run `./schema/install_schema.sh <auroradb-hostname>`
+
+NOTE: Please review to [UPGRADE.md](UPGRADE.md) for upgrade considerations.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,24 @@
+# Ariel Upgrade Documentation
+
+### v2.0.8
+
+Version 2.0.8 introduced some incompatible Aurora DB changes.
+
+* Addition of CMK / DBEngine / Snapshot support in auroradb.yaml CloudFormation Template
+  * Changing any of these parameters will rebuild your database which will
+    1. Alter your db connection endpoint
+    2. Delete all data in your database
+    3. Delete all automatic snapshots created for your database
+  * To enable CMK Encryption you should:
+    1. Create a manual snapshot of your database
+    2. Update your template specifying both UseCmk, and the DbSnapshotIdentifier that you created
+    3. DBEngine must match the version of your snapshot.
+    4. Once DbSnapshotIdentifier has been specified, the value must be maintained or the database will be rebuilt again.
+* Schema modifications to reserved_instances_recommendations and unlimited_usage tables
+  * Since these tables contain current data an no history, it was determined to be easier to just drop and recreate:
+    1. Connect to the database as aurora_dbo
+    2. drop table reserved_instances_recommendations;
+    3. drop table unlimited_usage;
+    4. \i schema/02_tbl_reserved_instances_recommendations.sql
+    5. \i schema/02_tbl_unlimited_usage.sql
+    6. Re-run Ariel Lambda to re-populate these tables

--- a/ariel/__init__.py
+++ b/ariel/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the terms of the Apache License, Version 2.0. See LICENSE file for terms.
 __all__ = ['generate_reports', 'get_account_instance_summary', 'get_account_names', 'get_ec2_pricing', 'get_locations',
            'get_reserved_instances', 'get_unlimited_summary', 'get_unused_box_summary', 'utils', 'LOGGER']
-__version__='2.0.7'
+__version__='2.0.8'
 
 import logging
 LOG_LEVEL = logging.INFO

--- a/ariel/generate_reports.py
+++ b/ariel/generate_reports.py
@@ -53,7 +53,7 @@ def generate(config, instances, ris, pricing):
     instances.insert(family_column, 'instancetypefamily', family_value)
 
     # Amazon still hasn't fixed g4dn, so we need to filter out instance types that we don't have size data about.
-    instances = instances[instances.instancetype.isin(pricing['units'].keys())]
+    instances = instances[instances.instancetype.isin(pricing['units'].keys())].reset_index(drop=True)
 
     instance_units_column = instances.columns.get_loc('instances') + 2
     units_value = instances['instancetype'].apply(get_units) * instances['instances']

--- a/ariel/lambda.py
+++ b/ariel/lambda.py
@@ -66,12 +66,11 @@ def lambda_main(config):
             LOGGER.info("Writing Report {} to {}...".format(key, filename))
 
             # Decorate report
-            try:
+            if 'accountid' in report.columns and 'accountname' not in report.columns:
                 accountname_column = report.columns.get_loc('accountid') + 1
-                accountname_value = report['accountid'].apply(lambda x: account_names[x] if x in account_names else x)
+                input_column = 'Account ID' if 'Account ID' in report.columns else 'accountid'
+                accountname_value = report[input_column].apply(lambda x: account_names[x] if x in account_names else x)
                 report.insert(accountname_column, 'accountname', accountname_value)
-            except KeyError:
-                pass
 
             # Write report
             with utils.get_temp_write_handle(filename) as output:

--- a/cloudformation/auroradb.yaml
+++ b/cloudformation/auroradb.yaml
@@ -12,13 +12,18 @@ Parameters:
   DbInstanceType:
     Description: The instance type to use for the database
     Type: String
-    Default: db.r4.2xlarge
+    Default: db.r5.xlarge
     AllowedValues:
       - db.r4.large
       - db.r4.xlarge
       - db.r4.2xlarge
       - db.r4.4xlarge
       - db.r4.8xlarge
+      - db.r5.large
+      - db.r5.xlarge
+      - db.r5.2xlarge
+      - db.r5.4xlarge
+      - db.r5.12xlarge
   PubliclyAccessible:
     Description: Attach a public IP to the DB Cluster
     Type: String
@@ -28,12 +33,34 @@ Parameters:
     Description: CIDR allowed to connect to Aurora
     Type: String
     Default: "10.0.0.0/8"
+  DbEngineVersion:
+    Description: "The version of Aurora PostgreSQL to run.  NOTE: Changing this value will rebuild your database.  Use a manual snapshot to preserve your data."
+    Type: String
+    AllowedValues:
+      - 10.6
+      - 10.7
+    Default: "10.6"
+  UseCmk:
+    Description: "Create and attach a KMS CMK for DB Encryption.  NOTE: Changing this value will rebuild your database.  Use a manual snapshot to preserve your data."
+    Type: String
+    Default: false
+    AllowedValues: [ 'true', 'false' ]
+  DbSnapshotIdentifier:
+    Description: "The snapshot to restore.  NOTE: Keep previous value to avoid a database rebuild."
+    Type: String
+    Default: ""
 
 Metadata:
     AWS::CloudFormation::Interface:
         ParameterGroups:
           - Label: { default: 'Aurora Parameters' }
             Parameters: [ "VpcId", "Subnets", "DbInstanceType", "PubliclyAccessible", "AllowedIngress" ]
+          - Label: { default: 'Dangerous Parameters' }
+            Parameters: [ "DbEngineVersion", "UseCmk", "DbSnapshotIdentifier" ]
+
+Conditions:
+  UseDbSnapshot: !Not [ !Equals [ !Ref "DbSnapshotIdentifier", "" ] ]
+  UseCmk: !Equals [ !Ref "UseCmk", "true" ]
 
 Resources:
   DboPassword:
@@ -69,6 +96,25 @@ Resources:
       Tags:
         - Key: Name
           Value: ariel-aurora
+  KMSKey:
+    Type: AWS::KMS::Key
+    Condition: UseCmk
+    Properties:
+      Description: "KMS Encryption Key for Ariel database"
+      Enabled: true
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Sid: "Enable IAM User Permissions"
+            Effect: "Allow"
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action: "kms:*"
+            Resource: "*"
+      Tags:
+        - Key: Name
+          Value: ariel-aurora
   DbCluster:
     Type: AWS::RDS::DBCluster
     Properties:
@@ -78,12 +124,14 @@ Resources:
       DBSubnetGroupName: !Ref 'DbSubnetGroup'
       EnableIAMDatabaseAuthentication: true
       Engine: aurora-postgresql
-      EngineVersion: 10.6
-      MasterUsername: !Sub "{{resolve:secretsmanager:${DboPassword}:SecretString:username}}"
+      EngineVersion: !Ref 'DbEngineVersion'
+      KmsKeyId: !If [ "UseCmk", !Ref "KMSKey", !Ref "AWS::NoValue" ]
+      MasterUsername: !If [ "UseDbSnapshot", !Ref "AWS::NoValue", !Sub "{{resolve:secretsmanager:${DboPassword}:SecretString:username}}" ]
       MasterUserPassword: !Sub "{{resolve:secretsmanager:${DboPassword}:SecretString:password}}"
       Port: 5432
       PreferredBackupWindow: 05:00-06:00
       PreferredMaintenanceWindow: mon:06:00-mon:07:00
+      SnapshotIdentifier: !If [ "UseDbSnapshot", !Ref "DbSnapshotIdentifier", !Ref "AWS::NoValue" ]
       StorageEncrypted: true
       VpcSecurityGroupIds:
         - !Ref 'SecurityGroup'

--- a/cloudformation/auroradb.yaml
+++ b/cloudformation/auroradb.yaml
@@ -115,6 +115,12 @@ Resources:
       Tags:
         - Key: Name
           Value: ariel-aurora
+  KeyAlias:
+    Type: AWS::KMS::Alias
+    Condition: UseCmk
+    Properties:
+      AliasName: "alias/ariel-aurora"
+      TargetKeyId: !Ref KMSKey
   DbCluster:
     Type: AWS::RDS::DBCluster
     Properties:

--- a/schema/02_tbl_reserved_instances_recommendations.sql
+++ b/schema/02_tbl_reserved_instances_recommendations.sql
@@ -4,18 +4,17 @@ SET client_min_messages TO warning;
 
 CREATE TABLE reserved_instances_recommendations
 (
-    "Account Id"          character(19)               NOT NULL,
+    "Account ID"          character(12)               NOT NULL,
     "Scope"               character varying(16)       NOT NULL, -- [Region, Availabilty Zone]
     "Region"              character varying(20)       NOT NULL, -- ap-northeast-3 + 6
-    "External AZ"         character varying(21)       NULL,     -- region + 1
-    "Offering Class"      character varying(11)       NOT NULL, -- [classic, convertible]
-    "Quantity"            smallint                    NOT NULL,
-    "Term"                smallint                    NOT NULL, -- [12, 36]
     "Instance Type"       character varying(15)       NOT NULL, -- r5ad.24xlarge + 2
-    "Product Description" character varying(7)        NOT NULL, -- [Linux, RHEL, SUSE, Windows]
-    "RI Type"             character varying(15)       NOT NULL, -- [All Upfront, Partial Upfront, No Upfront]
+    "Operating System"    character varying(23)       NOT NULL, -- [Linux/UNIX (Amazon VPC), RHEL, SUSE, Windows]
     "Tenancy"             character varying(9)        NOT NULL, -- [Dedicated, Host, Shared]
-    accountid             character(12)               NOT NULL,
+    "Offering Class"      character varying(11)       NOT NULL, -- [classic, convertible]
+    "Payment Type"        character varying(15)       NOT NULL, -- [All Upfront, Partial Upfront, No Upfront]
+    "Term"                smallint                    NOT NULL, -- [12, 36]
+    "Quantity"            smallint                    NOT NULL,
+    accountid             character(19)               NOT NULL,
     accountname           character varying(64)       NOT NULL,
     family                character varying(5)        NOT NULL, -- r5ad + 1
     units                 double precision            NOT NULL,

--- a/schema/02_tbl_unlimited_usage.sql
+++ b/schema/02_tbl_unlimited_usage.sql
@@ -7,7 +7,7 @@ CREATE TABLE unlimited_usage
     accountid            character(12)               NOT NULL,
     accountname          character varying(64)       NOT NULL,
     region               character varying(20)       NOT NULL, -- ap-northeast-3 + 6
-    instancetypefamily   character varying(2)        NOT NULL, -- [t2, t3]
+    instancetypefamily   character varying(3)        NOT NULL, -- [t2, t3, t3a]
     unlimitedusageamount double precision            NOT NULL,
     unlimitedusagecost   money                       NOT NULL,
 	PRIMARY KEY (accountid, region, instancetypefamily)


### PR DESCRIPTION
Initial maintenance work to add CMK support in Aurora DB uncovered multiple bugs that also needed to be addressed.

## Description
1. Added support for CMK Encryption of the Aurora Database.
2. To support migration to CMK Encryption, added restore from snapshot support.
3. To support manually upgraded databases, added DBEngine support.
4. Added support for r5 database instance type.  Updated default to be r5.xlarge.
5. Added support for storing RI Summary report (equivalent to RI Fleet Report)
6. Update to filter out instance types where we do not have size information about.  This is to address an issue where Amazon is not publishing Normalization Size Factor for the g4dn instance types.
7. Fixed a bug introduced in 2.0.7 where account name lookup would fail after column reordering.
8. Updated reserved_instances_recommendations schema to match column reordering introduced in 2.0.7
9. Updated unlimited_usage schema to support t3a instance types

## Motivation and Context
CMK Update required by business initiative.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.


## License  
I confirm that this contribution is made under the Apache License, Version 2.0 and that I have the authority necessary to make this contribution on behalf of its copyright owner.